### PR TITLE
Update build_network.py

### DIFF
--- a/model_analysis_folders/visual_networks/CLIP_ViT-B_32/build_network.py
+++ b/model_analysis_folders/visual_networks/CLIP_ViT-B_32/build_network.py
@@ -101,7 +101,8 @@ def build_net(ds_kwargs={}, return_metamer_layers=False, dataset_name='ImageNet'
 
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    model, preprocess = clip.load("ViT-B/32", device=device, jit=False)
+    # Build the model on the CPU, which will make sure that the floats are float32
+    model, preprocess = clip.load("ViT-B/32", device=torch.device("cpu"), jit=False)
     model.to(device)
 
     model = CLIPModelWithLabels(model, device=device)


### PR DESCRIPTION
Edit the CLIP model to build first on CPU, then on GPU to make sure that the model is float32. 

Note: This was in the code used for the Feather et al. 2023 paper, it seems to have been removed during cleanup for the public release.